### PR TITLE
Nested policy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,11 @@ If `race` is enable, we will get `NXDOMAIN` result quickly, otherwise we will ge
 Sends parallel requests between two randomly selected resolvers. Note, that `127.0.0.1:9007` would be selected more frequently as it has the highest `load-factor`.
 ~~~ corefile
 example.org {
-    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007
-    policy weighted-random {
-      server-count 2
-      load-factor 50 70 100
+    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007 {
+      policy weighted-random {
+        server-count 2
+        load-factor 50 70 100
+      }
     }
 }
 ~~~
@@ -130,7 +131,8 @@ example.org {
 Sends parallel requests between three resolver sequentially (default mode).
 ~~~ corefile
 example.org {
-    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007
-    policy sequential
+    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007 {
+      policy sequential
+    }
 }
 ~~~

--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ example.org {
 Sends parallel requests between three resolver sequentially (default mode).
 ~~~ corefile
 example.org {
-    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007 {
-        policy sequential
-    }
+    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007
+    policy sequential
 }
 ~~~

--- a/README.md
+++ b/README.md
@@ -119,11 +119,10 @@ If `race` is enable, we will get `NXDOMAIN` result quickly, otherwise we will ge
 Sends parallel requests between two randomly selected resolvers. Note, that `127.0.0.1:9007` would be selected more frequently as it has the highest `weighted-random-load-factor`.
 ~~~ corefile
 example.org {
-    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007 {
-      policy weighted-random
-      weighted-random-server-count 2
-      weighted-random-load-factor 50 70 100
-    }
+    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007
+    policy weighted-random
+    weighted-random-server-count 2
+    weighted-random-load-factor 50 70 100
 }
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Each incoming DNS query that hits the CoreDNS fanout plugin will be replicated i
 * `worker-count` is the number of parallel queries per request. By default equals to count of IP list. Use this only for reducing parallel queries per request.
 * `policy` - specifies the policy of DNS server selection mechanism. The default is `sequential`.
   * `sequential` - select DNS servers one-by-one based on its order
-  * `weighted-random` - select DNS servers randomly based on `weighted-random-server-count` and `weighted-random-load-factor` params.
-* `weighted-random-server-count` is the number of DNS servers to be requested. Equals to the number of specified IPs by default. Used only with the `weighted-random` policy.
-* `weighted-random-load-factor` - the probability of selecting a server. This is specified in the order of the list of IP addresses and takes values between 1 and 100. By default, all servers have an equal probability of 100. Used only with the `weighted-random` policy.
+  * `weighted-random` - select DNS servers randomly based on `server-count` and `load-factor` params:
+    * `server-count` is the number of DNS servers to be requested. Equals to the number of specified IPs by default.
+    * `load-factor` - the probability of selecting a server. This is specified in the order of the list of IP addresses and takes values between 1 and 100. By default, all servers have an equal probability of 100.
 * `network` is a specific network protocol. Could be `tcp`, `udp`, `tcp-tls`.
 * `except` is a list is a space-separated list of domains to exclude from proxying.
 * `except-file` is the path to file with line-separated list of domains to exclude from proxying.
@@ -116,13 +116,14 @@ If `race` is enable, we will get `NXDOMAIN` result quickly, otherwise we will ge
 }
 ~~~
 
-Sends parallel requests between two randomly selected resolvers. Note, that `127.0.0.1:9007` would be selected more frequently as it has the highest `weighted-random-load-factor`.
+Sends parallel requests between two randomly selected resolvers. Note, that `127.0.0.1:9007` would be selected more frequently as it has the highest `load-factor`.
 ~~~ corefile
 example.org {
     fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007
-    policy weighted-random
-    weighted-random-server-count 2
-    weighted-random-load-factor 50 70 100
+    policy weighted-random {
+      server-count 2
+      load-factor 50 70 100
+    }
 }
 ~~~
 

--- a/fanout.go
+++ b/fanout.go
@@ -49,8 +49,6 @@ type Fanout struct {
 	attempts              int
 	workerCount           int
 	serverCount           int
-	loadFactor            []int
-	policyType            string
 	serverSelectionPolicy policy
 	tapPlugin             *dnstap.Dnstap
 	Next                  plugin.Handler

--- a/setup_test.go
+++ b/setup_test.go
@@ -125,10 +125,8 @@ func TestSetup(t *testing.T) {
 			if !reflect.DeepEqual(selectionPolicy.loadFactor, test.expectedLoadFactor) {
 				t.Fatalf("Test %d: expected: %d, got: %d", i, test.expectedLoadFactor, selectionPolicy.loadFactor)
 			}
-		} else {
-			if ok {
-				t.Fatalf("Test %d: expected sequential policy to be set, got: %T", i, f.serverSelectionPolicy)
-			}
+		} else if ok {
+			t.Fatalf("Test %d: expected sequential policy to be set, got: %T", i, f.serverSelectionPolicy)
 		}
 	}
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -40,19 +40,18 @@ func TestSetup(t *testing.T) {
 		expectedNetwork     string
 		expectedServerCount int
 		expectedLoadFactor  []int
-		expectedPolicy      string
 		expectedErr         string
 	}{
 		// positive
-		{input: "fanout . 127.0.0.1 {\npolicy weighted-random \nweighted-random-server-count 5 weighted-random-load-factor 100\n}", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 1, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 1, expectedLoadFactor: []int{100}, expectedPolicy: policyWeightedRandom},
-		{input: "fanout . 127.0.0.1", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 1, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 1, expectedLoadFactor: nil, expectedPolicy: ""},
-		{input: "fanout . 127.0.0.1 {\npolicy weighted-random \nserver-count 5 load-factor 100\n}", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 1, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 1, expectedLoadFactor: []int{100}, expectedPolicy: policyWeightedRandom},
-		{input: "fanout . 127.0.0.1 {\nexcept a b\nworker-count 3\n}", expectedFrom: ".", expectedTimeout: defaultTimeout, expectedAttempts: 3, expectedWorkers: 1, expectedIgnored: []string{"a.", "b."}, expectedNetwork: "udp", expectedServerCount: 1, expectedLoadFactor: nil, expectedPolicy: ""},
-		{input: "fanout . 127.0.0.1 127.0.0.2 {\nnetwork tcp\n}", expectedFrom: ".", expectedTimeout: defaultTimeout, expectedAttempts: 3, expectedWorkers: 2, expectedNetwork: "tcp", expectedTo: []string{"127.0.0.1:53", "127.0.0.2:53"}, expectedServerCount: 2, expectedLoadFactor: nil, expectedPolicy: ""},
-		{input: "fanout . 127.0.0.1 127.0.0.2 127.0.0.3 127.0.0.4 {\nworker-count 3\ntimeout 1m\n}", expectedTimeout: time.Minute, expectedAttempts: 3, expectedFrom: ".", expectedWorkers: 3, expectedNetwork: "udp", expectedServerCount: 4, expectedLoadFactor: nil, expectedPolicy: ""},
-		{input: "fanout . 127.0.0.1 127.0.0.2 127.0.0.3 127.0.0.4 {\nattempt-count 2\n}", expectedTimeout: defaultTimeout, expectedFrom: ".", expectedAttempts: 2, expectedWorkers: 4, expectedNetwork: "udp", expectedServerCount: 4, expectedLoadFactor: nil, expectedPolicy: ""},
-		{input: "fanout . 127.0.0.1 127.0.0.2 127.0.0.3 {\npolicy weighted-random \n}", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 3, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 3, expectedLoadFactor: []int{100, 100, 100}, expectedPolicy: policyWeightedRandom},
-		{input: "fanout . 127.0.0.1 127.0.0.2 127.0.0.3 {\npolicy sequential\nworker-count 3\n}", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 3, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 3, expectedLoadFactor: nil, expectedPolicy: policySequential},
+		{input: "fanout . 127.0.0.1 {\npolicy weighted-random {\nserver-count 5 load-factor 100\n}", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 1, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 1, expectedLoadFactor: []int{100}},
+		{input: "fanout . 127.0.0.1", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 1, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 1, expectedLoadFactor: nil},
+		{input: "fanout . 127.0.0.1 {\npolicy weighted-random {\nserver-count 5 load-factor 100\n}", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 1, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 1, expectedLoadFactor: []int{100}},
+		{input: "fanout . 127.0.0.1 {\nexcept a b\nworker-count 3\n}", expectedFrom: ".", expectedTimeout: defaultTimeout, expectedAttempts: 3, expectedWorkers: 1, expectedIgnored: []string{"a.", "b."}, expectedNetwork: "udp", expectedServerCount: 1, expectedLoadFactor: nil},
+		{input: "fanout . 127.0.0.1 127.0.0.2 {\nnetwork tcp\n}", expectedFrom: ".", expectedTimeout: defaultTimeout, expectedAttempts: 3, expectedWorkers: 2, expectedNetwork: "tcp", expectedTo: []string{"127.0.0.1:53", "127.0.0.2:53"}, expectedServerCount: 2, expectedLoadFactor: nil},
+		{input: "fanout . 127.0.0.1 127.0.0.2 127.0.0.3 127.0.0.4 {\nworker-count 3\ntimeout 1m\n}", expectedTimeout: time.Minute, expectedAttempts: 3, expectedFrom: ".", expectedWorkers: 3, expectedNetwork: "udp", expectedServerCount: 4, expectedLoadFactor: nil},
+		{input: "fanout . 127.0.0.1 127.0.0.2 127.0.0.3 127.0.0.4 {\nattempt-count 2\n}", expectedTimeout: defaultTimeout, expectedFrom: ".", expectedAttempts: 2, expectedWorkers: 4, expectedNetwork: "udp", expectedServerCount: 4, expectedLoadFactor: nil},
+		{input: "fanout . 127.0.0.1 127.0.0.2 127.0.0.3 {\npolicy weighted-random {}\n}", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 3, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 3, expectedLoadFactor: []int{100, 100, 100}},
+		{input: "fanout . 127.0.0.1 127.0.0.2 127.0.0.3 {\npolicy sequential\nworker-count 3\n}", expectedFrom: ".", expectedAttempts: 3, expectedWorkers: 3, expectedTimeout: defaultTimeout, expectedNetwork: "udp", expectedServerCount: 3, expectedLoadFactor: nil},
 
 		// negative
 		{input: "fanout . aaa", expectedErr: "not an IP address or file"},
@@ -61,12 +60,13 @@ func TestSetup(t *testing.T) {
 		{input: "fanout . 127.0.0.1 {\nexcept a b\nworker-count ten\n}", expectedErr: "'ten'"},
 		{input: "fanout . 127.0.0.1 {\nexcept a:\nworker-count ten\n}", expectedErr: "unable to normalize 'a:'"},
 		{input: "fanout . 127.0.0.1 127.0.0.2 {\nnetwork XXX\n}", expectedErr: "unknown network protocol"},
-		{input: "fanout . 127.0.0.1 {\npolicy weighted-random \nweighted-random-server-count -100\n}", expectedErr: "Wrong argument count or unexpected line ending"},
-		{input: "fanout . 127.0.0.1 {\npolicy weighted-random \nweighted-random-load-factor 150\n}", expectedErr: "load-factor 150 should be less than 100"},
-		{input: "fanout . 127.0.0.1 {\npolicy weighted-random \nweighted-random-load-factor 0\n}", expectedErr: "load-factor should be more or equal 1"},
-		{input: "fanout . 127.0.0.1 {\npolicy weighted-random \nweighted-random-load-factor 50 100\n}", expectedErr: "load-factor params count must be the same as the number of hosts"},
-		{input: "fanout . 127.0.0.1 127.0.0.2 {\npolicy weighted-random \nweighted-random-load-factor 50\n}", expectedErr: "load-factor params count must be the same as the number of hosts"},
-		{input: "fanout . 127.0.0.1 127.0.0.2 {\npolicy weighted-random \nweighted-random-load-factor \n}", expectedErr: "Wrong argument count or unexpected line ending"},
+		{input: "fanout . 127.0.0.1 {\npolicy weighted-random {\nserver-count -100\n}\n}", expectedErr: "Wrong argument count or unexpected line ending"},
+		{input: "fanout . 127.0.0.1 {\npolicy weighted-random {\nload-factor 150\n}\n}", expectedErr: "load-factor 150 should be less than 100"},
+		{input: "fanout . 127.0.0.1 {\npolicy weighted-random {\nload-factor 0\n}\n}", expectedErr: "load-factor should be more or equal 1"},
+		{input: "fanout . 127.0.0.1 {\npolicy weighted-random {\nload-factor 50 100\n}\n}", expectedErr: "load-factor params count must be the same as the number of hosts"},
+		{input: "fanout . 127.0.0.1 127.0.0.2 {\npolicy weighted-random {\nload-factor 50\n}\n}", expectedErr: "load-factor params count must be the same as the number of hosts"},
+		{input: "fanout . 127.0.0.1 127.0.0.2 {\npolicy weighted-random {\nload-factor \n}\n}", expectedErr: "Wrong argument count or unexpected line ending"},
+		{input: "fanout . 127.0.0.1 127.0.0.2 {\npolicy weighted-random\nworker-count 10\n}", expectedErr: "Wrong policy configuration"},
 	}
 
 	for i, test := range tests {
@@ -116,9 +116,6 @@ func TestSetup(t *testing.T) {
 		if f.serverCount != test.expectedServerCount {
 			t.Fatalf("Test %d: expected: %d, got: %d", i, test.expectedServerCount, f.serverCount)
 		}
-		if f.policyType != test.expectedPolicy {
-			t.Fatalf("Test %d: expected: %s, got: %s", i, test.expectedPolicy, f.policyType)
-		}
 
 		selectionPolicy, ok := f.serverSelectionPolicy.(*weightedPolicy)
 		if len(test.expectedLoadFactor) > 0 {
@@ -128,8 +125,10 @@ func TestSetup(t *testing.T) {
 			if !reflect.DeepEqual(selectionPolicy.loadFactor, test.expectedLoadFactor) {
 				t.Fatalf("Test %d: expected: %d, got: %d", i, test.expectedLoadFactor, selectionPolicy.loadFactor)
 			}
-		} else if ok {
-			t.Fatalf("Test %d: expected sequential policy to be set, got: %T", i, f.serverSelectionPolicy)
+		} else {
+			if ok {
+				t.Fatalf("Test %d: expected sequential policy to be set, got: %T", i, f.serverSelectionPolicy)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Get nested policy configuration back:
```
example.org {
    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007 {
      policy weighted-random {
        server-count 2
        load-factor 50 70 100
      }
    }
}
```

Instead of:
```
example.org {
    fanout . 127.0.0.1:9005 127.0.0.1:9006 127.0.0.1:9007 {
      policy weighted-random
      weighted-random-server-count 2
      weighted-random-load-factor 50 70 100
    }
}
```